### PR TITLE
feat: agregar verificación de consistencia entre chats y registros di…

### DIFF
--- a/src/controllers/quicklearning/metricsController.ts
+++ b/src/controllers/quicklearning/metricsController.ts
@@ -1,5 +1,7 @@
 import { Request, Response } from "express";
 import mongoose from "mongoose";
+import { getConnectionByCompanySlug } from "../../config/connectionManager";
+import getRecordModel from "../../models/record.model";
 
 // Importar el modelo de QuickLearning chat
 interface IQuickLearningChat {
@@ -51,16 +53,24 @@ interface QuickLearningMetrics {
   humanResponses: number;
   asesorResponses: number;
   averageResponseTime: number;
+  totalRecordsCreated: number;
+  recordsBySlug: Record<string, number>;
   dailyBreakdown: Array<{
     date: string;
-    totalChats: number;
-    newChats: number;
+    totalChats: number; // chats con actividad por mensajes ese día
+    newChats: number; // chats creados ese día (por createdAt)
+    prospectosCreated: number; // records 'prospectos' creados ese día
+    recordsCreated: number; // total records creados (slugs seleccionados)
+    recordsBySlug: Record<string, number>;
+    campaignsProspectos?: Array<{ name: string; count: number }>;
+    campaignsProspectosSummary?: { withCampaign: number; withoutCampaign: number; numCampaigns: number };
     totalMessages: number;
     inboundMessages: number;
     outboundMessages: number;
     averageMessagesPerChat: number;
     botResponses: number;
     humanResponses: number;
+    uniqueInboundConversations: number;
   }>;
   hourlyDistribution: Array<{
     hour: number;
@@ -98,7 +108,8 @@ export const getQuickLearningMetrics = async (req: Request, res: Response): Prom
       startDate, 
       endDate, 
       period = '7days',
-      includeInactive = 'false'
+      includeInactive = 'false',
+      tableSlugs
     } = req.query;
 
     console.log(`📊 Obteniendo métricas de QuickLearning...`);
@@ -107,12 +118,16 @@ export const getQuickLearningMetrics = async (req: Request, res: Response): Prom
     // Calcular rango de fechas
     let dateFilter: any = {};
     const now = new Date();
+    let periodStart: Date;
+    let periodEnd: Date;
     
     if (startDate && endDate) {
+      periodStart = new Date(startDate as string);
+      periodEnd = new Date(endDate as string);
       dateFilter = {
         createdAt: {
-          $gte: new Date(startDate as string),
-          $lte: new Date(endDate as string)
+          $gte: periodStart,
+          $lte: periodEnd
         }
       };
     } else {
@@ -121,9 +136,10 @@ export const getQuickLearningMetrics = async (req: Request, res: Response): Prom
                          period === '7days' ? 24 * 7 : 
                          period === '30days' ? 24 * 30 : 24 * 7;
       
-      const startTime = new Date(now.getTime() - (periodHours * 60 * 60 * 1000));
+      periodStart = new Date(now.getTime() - (periodHours * 60 * 60 * 1000));
+      periodEnd = now;
       dateFilter = {
-        createdAt: { $gte: startTime }
+        createdAt: { $gte: periodStart, $lte: periodEnd }
       };
     }
 
@@ -177,12 +193,143 @@ export const getQuickLearningMetrics = async (req: Request, res: Response): Prom
     const QuickLearningChat = quickLearningConnection.model<IQuickLearningChat>('Chat', quickLearningChatSchema);
 
     // Consultar chats
-    const chats = await QuickLearningChat.find({
+    const chatsRaw = await QuickLearningChat.find({
       ...dateFilter,
       ...statusFilter
     }).lean();
 
-    console.log(`📊 Chats encontrados: ${chats.length}`);
+    console.log(`📊 Chats encontrados (antes de match DynamicRecords): ${chatsRaw.length}`);
+
+    // Obtener teléfonos válidos desde DynamicRecords para asegurar 1:1 con registros
+    const defaultSlugs = ["alumnos", "prospectos", "clientes", "sin_contestar", "nuevo_ingreso"];
+    const slugs = (typeof tableSlugs === 'string' && tableSlugs.trim().length > 0)
+      ? (tableSlugs as string).split(',').map(s => s.trim()).filter(Boolean)
+      : defaultSlugs;
+
+    // Conexión a BD de empresa (dynamicrecords)
+    const companySlug = 'quicklearning';
+    const companyConn = await getConnectionByCompanySlug(companySlug);
+    const Record = getRecordModel(companyConn);
+
+    const recordQuery: any = {
+      c_name: companySlug,
+      tableSlug: { $in: slugs }
+    };
+
+    const dynamicRecords = await Record.find(recordQuery)
+      .select('data.telefono data.phone data.number tableSlug createdAt')
+      .lean();
+
+    const normalizePhoneVariants = (val: any): string[] => {
+      if (val === undefined || val === null) return [];
+      const s = String(val).trim();
+      if (!s) return [];
+      const digitsOnly = s.replace(/\D+/g, '');
+      const withoutPlus = s.startsWith('+') ? s.slice(1) : s;
+      return Array.from(new Set([s, withoutPlus, digitsOnly].filter(Boolean)));
+    };
+
+    const recordPhones = new Set<string>();
+    for (const r of dynamicRecords) {
+      const candidates = [r?.data?.telefono, r?.data?.phone, r?.data?.number];
+      for (const c of candidates) {
+        const variants = normalizePhoneVariants(c);
+        variants.forEach(v => recordPhones.add(v));
+      }
+    }
+
+    // Backfill: asegurar que por cada chat creado en el período exista un Record en 'prospectos' creado el mismo día
+    try {
+      const toCanonical = (val: any): string | null => {
+        if (val === undefined || val === null) return null;
+        const s = String(val).trim();
+        if (!s) return null;
+        return s.replace(/\D+/g, '');
+      };
+
+      // Mapear chats creados por día (por createdAt)
+      const chatsCreatedByDay = new Map<string, Array<any>>();
+      for (const c of chatsRaw) {
+        const created = (c as any).createdAt ? new Date((c as any).createdAt) : null;
+        if (!created || isNaN(created.getTime())) continue;
+        if (created < periodStart || created > periodEnd) continue;
+        const key = created.toISOString().split('T')[0];
+        if (!chatsCreatedByDay.has(key)) chatsCreatedByDay.set(key, []);
+        chatsCreatedByDay.get(key)!.push(c);
+      }
+
+      // Records 'prospectos' creados en el período
+      const prospectosRecords = await Record.find({
+        c_name: companySlug,
+        tableSlug: 'prospectos',
+        createdAt: { $gte: periodStart, $lte: periodEnd }
+      }).select('createdAt data.telefono data.phone data.number').lean();
+
+      const recordsByDay = new Map<string, Set<string>>();
+      for (const r of prospectosRecords) {
+        const created = (r as any).createdAt ? new Date((r as any).createdAt) : null;
+        if (!created || isNaN(created.getTime())) continue;
+        const key = created.toISOString().split('T')[0];
+        const canon = toCanonical((r as any).data?.telefono ?? (r as any).data?.phone ?? (r as any).data?.number);
+        if (!canon) continue;
+        if (!recordsByDay.has(key)) recordsByDay.set(key, new Set<string>());
+        recordsByDay.get(key)!.add(canon);
+      }
+
+      // Encontrar faltantes y preparar inserciones
+      const inserts: any[] = [];
+      for (const [dayKey, dayChats] of chatsCreatedByDay.entries()) {
+        const recordSet = recordsByDay.get(dayKey) || new Set<string>();
+        for (const chat of dayChats) {
+          const canon = toCanonical(chat?.phone);
+          if (!canon) continue;
+          if (!recordSet.has(canon)) {
+            inserts.push({
+              tableSlug: 'prospectos',
+              c_name: companySlug,
+              data: {
+                telefono: chat.phone,
+                phone: chat.phone,
+                number: canon,
+                name: (chat as any).customerInfo?.name || (chat as any).profileName || '',
+                lastMessageDate: (chat as any).lastMessage?.date || (chat as any).conversationStart,
+                source: 'auto-metrics-backfill'
+              },
+              createdBy: 'metrics-sync',
+              createdAt: (chat as any).createdAt || (chat as any).conversationStart,
+              updatedBy: 'metrics-sync',
+              updatedAt: (chat as any).createdAt || (chat as any).conversationStart
+            });
+            recordSet.add(canon);
+          }
+        }
+        recordsByDay.set(dayKey, recordSet);
+      }
+
+      if (inserts.length > 0) {
+        try {
+          await Record.insertMany(inserts, { ordered: false });
+          // Añadir a recordPhones para que los chats se incluyan
+          for (const ins of inserts) {
+            const variants = normalizePhoneVariants(ins.data?.phone || ins.data?.telefono || ins.data?.number);
+            variants.forEach((v: string) => recordPhones.add(v));
+          }
+          console.log(`🧩 Backfill: creados ${inserts.length} records faltantes en 'prospectos'`);
+        } catch (bulkErr) {
+          console.warn('⚠️ Error en insertMany de backfill:', bulkErr);
+        }
+      }
+    } catch (backfillError) {
+      console.warn('⚠️ Backfill de records faltantes falló:', backfillError);
+    }
+
+    const chats = chatsRaw.filter(c => {
+      if (!c?.phone) return false;
+      const variants = normalizePhoneVariants(c.phone);
+      return variants.some(v => recordPhones.has(v));
+    });
+
+    console.log(`📊 Chats después de match DynamicRecords (${slugs.join(', ')}): ${chats.length}`);
 
     // Calcular métricas
     const metrics: QuickLearningMetrics = {
@@ -200,6 +347,8 @@ export const getQuickLearningMetrics = async (req: Request, res: Response): Prom
       humanResponses: 0,
       asesorResponses: 0,
       averageResponseTime: 0,
+      totalRecordsCreated: 0,
+      recordsBySlug: {},
       dailyBreakdown: [],
       hourlyDistribution: [],
       stageDistribution: {
@@ -291,21 +440,32 @@ export const getQuickLearningMetrics = async (req: Request, res: Response): Prom
         if (!dailyData[dateKey]) {
           dailyData[dateKey] = {
             date: dateKey,
-            totalChats: new Set(),
-            newChats: new Set(),
+            totalChatsSet: new Set<string>(),
+            newChatsSet: new Set<string>(),
+            prospectosCreated: 0,
+            recordsCreated: 0,
+            recordsBySlug: {},
+            campaignsMapProspectos: new Map<string, number>(),
+            withCampaignProspectos: 0,
+            withoutCampaignProspectos: 0,
             totalMessages: 0,
             inboundMessages: 0,
             outboundMessages: 0,
             botResponses: 0,
-            humanResponses: 0
+            humanResponses: 0,
+            uniqueInboundConversations: new Set<string>(),
           };
         }
         
-        dailyData[dateKey].totalChats.add(chat.phone);
+        dailyData[dateKey].totalChatsSet.add(chat.phone);
         dailyData[dateKey].totalMessages++;
         
-        if (message.direction === 'inbound') dailyData[dateKey].inboundMessages++;
-        else dailyData[dateKey].outboundMessages++;
+        if (message.direction === 'inbound') {
+          dailyData[dateKey].inboundMessages++;
+          dailyData[dateKey].uniqueInboundConversations.add(chat.phone);
+        } else {
+          dailyData[dateKey].outboundMessages++;
+        }
         
         if (message.respondedBy === 'bot') dailyData[dateKey].botResponses++;
         else if (message.respondedBy === 'human' || message.respondedBy === 'asesor') {
@@ -320,12 +480,85 @@ export const getQuickLearningMetrics = async (req: Request, res: Response): Prom
         hourlyData[hour].chats.add(chat.phone);
       });
 
-      // Detectar nuevos chats por día
-      const chatStartDate = new Date(chat.conversationStart).toISOString().split('T')[0];
-      if (dailyData[chatStartDate]) {
-        dailyData[chatStartDate].newChats.add(chat.phone);
+      // Registrar chat creado por día (usar createdAt)
+      const chatCreatedDate = new Date((chat as any).createdAt || chat.conversationStart);
+      const chatCreatedKey = chatCreatedDate.toISOString().split('T')[0];
+      if (!dailyData[chatCreatedKey]) {
+        dailyData[chatCreatedKey] = {
+          date: chatCreatedKey,
+          totalChatsSet: new Set<string>(),
+          newChatsSet: new Set<string>(),
+          prospectosCreated: 0,
+          recordsCreated: 0,
+          recordsBySlug: {},
+          campaignsMapProspectos: new Map<string, number>(),
+          withCampaignProspectos: 0,
+          withoutCampaignProspectos: 0,
+          totalMessages: 0,
+          inboundMessages: 0,
+          outboundMessages: 0,
+          botResponses: 0,
+          humanResponses: 0,
+          uniqueInboundConversations: new Set<string>(),
+        };
       }
+      dailyData[chatCreatedKey].newChatsSet.add(chat.phone);
     });
+
+    // Contar records creados por día (para slugs seleccionados) y breakdown por slug
+    try {
+      const recordsCreated = await Record.find({
+        c_name: companySlug,
+        tableSlug: { $in: slugs },
+        createdAt: { $gte: periodStart, $lte: periodEnd }
+      }).select({ createdAt: 1, tableSlug: 1, 'data.campana': 1 }).lean();
+
+      const normalizeCampaign = (val: any): string => {
+        if (val === undefined || val === null) return 'SIN_CAMPANA';
+        const s = String(val).trim();
+        return s === '' ? 'SIN_CAMPANA' : s.toUpperCase();
+      };
+
+      for (const rec of recordsCreated as any[]) {
+        const created = rec?.createdAt ? new Date(rec.createdAt) : null;
+        if (!created || isNaN(created.getTime())) continue;
+        const key = created.toISOString().split('T')[0];
+        if (!dailyData[key]) {
+          dailyData[key] = {
+            date: key,
+            totalChatsSet: new Set<string>(),
+            newChatsSet: new Set<string>(),
+            prospectosCreated: 0,
+            recordsCreated: 0,
+            recordsBySlug: {},
+            campaignsMapProspectos: new Map<string, number>(),
+            withCampaignProspectos: 0,
+            withoutCampaignProspectos: 0,
+            totalMessages: 0,
+            inboundMessages: 0,
+            outboundMessages: 0,
+            botResponses: 0,
+            humanResponses: 0,
+            uniqueInboundConversations: new Set<string>(),
+          };
+        }
+        dailyData[key].recordsCreated = (dailyData[key].recordsCreated || 0) + 1;
+        const slug = rec.tableSlug || 'unknown';
+        dailyData[key].recordsBySlug[slug] = (dailyData[key].recordsBySlug[slug] || 0) + 1;
+        if (slug === 'prospectos') {
+          dailyData[key].prospectosCreated = (dailyData[key].prospectosCreated || 0) + 1;
+          const camp = normalizeCampaign(rec?.data?.campana);
+          const curr = dailyData[key].campaignsMapProspectos.get(camp) || 0;
+          dailyData[key].campaignsMapProspectos.set(camp, curr + 1);
+          if (camp === 'SIN_CAMPANA') dailyData[key].withoutCampaignProspectos += 1;
+          else dailyData[key].withCampaignProspectos += 1;
+        }
+        metrics.totalRecordsCreated += 1;
+        metrics.recordsBySlug[slug] = (metrics.recordsBySlug[slug] || 0) + 1;
+      }
+    } catch (e) {
+      console.warn('⚠️ No se pudieron contar records creados por día:', e);
+    }
 
     // Calcular promedios y medianas
     if (messagesPerChat.length > 0) {
@@ -345,14 +578,27 @@ export const getQuickLearningMetrics = async (req: Request, res: Response): Prom
     // Procesar datos diarios
     metrics.dailyBreakdown = Object.values(dailyData).map((day: any) => ({
       date: day.date,
-      totalChats: day.totalChats.size,
-      newChats: day.newChats.size,
+      // A solicitud: usar PROSPECTOS creados como "Total Chats" del día (total campañas)
+      totalChats: day.prospectosCreated || 0,
+      newChats: day.newChatsSet.size,
+      prospectosCreated: day.prospectosCreated || 0,
+      recordsCreated: day.recordsCreated || 0,
+      recordsBySlug: day.recordsBySlug || {},
+      campaignsProspectos: Array.from((day.campaignsMapProspectos || new Map()).entries())
+        .map(([name, count]: [string, number]) => ({ name, count }))
+        .sort((a, b) => b.count - a.count),
+      campaignsProspectosSummary: {
+        withCampaign: day.withCampaignProspectos || 0,
+        withoutCampaign: day.withoutCampaignProspectos || 0,
+        numCampaigns: (day.campaignsMapProspectos ? day.campaignsMapProspectos.size : 0)
+      },
       totalMessages: day.totalMessages,
       inboundMessages: day.inboundMessages,
       outboundMessages: day.outboundMessages,
-      averageMessagesPerChat: day.totalChats.size > 0 ? day.totalMessages / day.totalChats.size : 0,
+      averageMessagesPerChat: day.totalChatsSet.size > 0 ? day.totalMessages / day.totalChatsSet.size : 0,
       botResponses: day.botResponses,
-      humanResponses: day.humanResponses
+      humanResponses: day.humanResponses,
+      uniqueInboundConversations: day.uniqueInboundConversations ? day.uniqueInboundConversations.size : 0
     })).sort((a, b) => a.date.localeCompare(b.date));
 
     // Procesar datos por hora
@@ -375,8 +621,11 @@ export const getQuickLearningMetrics = async (req: Request, res: Response): Prom
     // Cerrar conexión
     await quickLearningConnection.close();
 
+    // A solicitud: usar total de PROSPECTOS creados como "Total Chats" del período (total campañas)
+    metrics.totalChats = metrics.recordsBySlug['prospectos'] || 0;
+
     console.log(`✅ Métricas calculadas exitosamente`);
-    console.log(`📊 Total chats: ${metrics.totalChats}, Total mensajes: ${metrics.totalMessages}`);
+    console.log(`📊 Total (registros como chats): ${metrics.totalChats}, Total mensajes: ${metrics.totalMessages}`);
 
     return res.status(200).json({
       success: true,
@@ -385,6 +634,11 @@ export const getQuickLearningMetrics = async (req: Request, res: Response): Prom
         startDate: startDate || `últimos ${period}`,
         endDate: endDate || 'ahora',
         includeInactive: includeInactive === 'true'
+      },
+      constraints: {
+        matchedByDynamicRecords: true,
+        tableSlugs: slugs,
+        company: companySlug
       },
       generatedAt: new Date().toISOString()
     });
@@ -527,5 +781,190 @@ export const getQuickLearningDashboard = async (req: Request, res: Response): Pr
       message: 'Error interno del servidor',
       error: process.env.NODE_ENV === 'development' ? error : undefined
     });
+  }
+};
+
+/**
+ * Verificar consistencia entre Chats y DynamicRecords por tableSlug
+ * - Compara teléfonos presentes en 'chats' vs 'dynamicrecords'
+ * - Reporta faltantes en cada lado y posibles duplicados
+ */
+export const checkQuickLearningChatsRecordsConsistency = async (req: Request, res: Response): Promise<any> => {
+  try {
+    const {
+      startDate,
+      endDate,
+      period = '7days',
+      includeInactive = 'false',
+      tableSlugs
+    } = req.query;
+
+    const defaultSlugs = ["alumnos", "prospectos", "clientes", "sin_contestar", "nuevo_ingreso"];
+    const slugs = (typeof tableSlugs === 'string' && tableSlugs.trim().length > 0)
+      ? (tableSlugs as string).split(',').map(s => s.trim()).filter(Boolean)
+      : defaultSlugs;
+
+    // 1) Rango de fechas (usaremos mensajes.dateCreated y data.lastMessageDate)
+    const now = new Date();
+    let startTime: Date;
+    let endTime: Date;
+    if (startDate && endDate) {
+      startTime = new Date(startDate as string);
+      endTime = new Date(endDate as string);
+    } else {
+      const periodHours = period === '24hours' ? 24 : period === '7days' ? 24 * 7 : period === '30days' ? 24 * 30 : 24 * 7;
+      endTime = now;
+      startTime = new Date(now.getTime() - (periodHours * 60 * 60 * 1000));
+    }
+
+    let statusFilter: any = {};
+    if (includeInactive === 'false') {
+      statusFilter = { status: { $ne: 'inactive' } };
+    }
+
+    // 2) Cargar chats
+    const QUICKLEARNING_URI = process.env.MONGO_URI_QUICKLEARNING ||
+      "mongodb+srv://quicklearning:VV235.@quicklearning.ikdoszo.mongodb.net/prod?retryWrites=true&w=majority&appName=quicklearning";
+    const quickLearningConnection = mongoose.createConnection(QUICKLEARNING_URI);
+
+    const quickLearningChatSchema = new mongoose.Schema({
+      phone: String,
+      messages: [{
+        direction: String,
+        dateCreated: { type: Date, default: Date.now },
+      }],
+      status: String,
+    }, { timestamps: true, collection: 'chats' });
+
+    const QuickLearningChat = quickLearningConnection.model('Chat', quickLearningChatSchema);
+    // Chats con al menos un mensaje en el rango
+    const chatsRaw = await QuickLearningChat.find({
+      ...statusFilter,
+      'messages.dateCreated': { $gte: startTime, $lte: endTime }
+    }).select('phone messages').lean();
+
+    // 3) Cargar dynamicrecords de quicklearning para slugs
+    const companySlug = 'quicklearning';
+    const companyConn = await getConnectionByCompanySlug(companySlug);
+    const Record = getRecordModel(companyConn);
+    // Records activos en el rango por lastMessageDate (si existe) o creados en rango como fallback
+    const records = await Record.find({ 
+      c_name: companySlug, 
+      tableSlug: { $in: slugs },
+      $or: [
+        { 'data.lastMessageDate': { $gte: startTime, $lte: endTime } },
+        { 'data.lastMessageDate': { $exists: false } },
+      ]
+    })
+      .select('data.telefono data.phone data.number data.lastMessageDate tableSlug createdAt')
+      .lean();
+
+    const toCanonical = (val: any): string | null => {
+      if (val === undefined || val === null) return null;
+      const s = String(val).trim();
+      if (!s) return null;
+      const digitsOnly = s.replace(/\D+/g, '');
+      return digitsOnly || null;
+    };
+
+    // 4) Construir sets y mapas
+    const chatPhonesSet = new Set<string>();
+    const chatPhoneCounts = new Map<string, number>();
+    for (const c of chatsRaw) {
+      const canon = toCanonical(c?.phone);
+      if (!canon) continue;
+      chatPhonesSet.add(canon);
+      chatPhoneCounts.set(canon, (chatPhoneCounts.get(canon) || 0) + 1);
+    }
+
+    const recordPhonesSet = new Set<string>();
+    const recordPhoneCounts = new Map<string, number>();
+    const recordCanonToMeta = new Map<string, { slugs: Set<string>, fields: Set<string> }>();
+    for (const r of records) {
+      const priorityVal = r?.data?.telefono ?? r?.data?.phone ?? r?.data?.number;
+      const canon = toCanonical(priorityVal);
+      if (!canon) continue;
+      recordPhonesSet.add(canon);
+      recordPhoneCounts.set(canon, (recordPhoneCounts.get(canon) || 0) + 1);
+      if (!recordCanonToMeta.has(canon)) recordCanonToMeta.set(canon, { slugs: new Set<string>(), fields: new Set<string>() });
+      const meta = recordCanonToMeta.get(canon)!;
+      if (r.tableSlug) meta.slugs.add(r.tableSlug as any);
+      if (priorityVal === r?.data?.telefono) meta.fields.add('telefono');
+      if (priorityVal === r?.data?.phone) meta.fields.add('phone');
+      if (priorityVal === r?.data?.number) meta.fields.add('number');
+    }
+
+    // 5) Intersección y diferencias
+    const matchedCanonPhones: string[] = [];
+    const chatsWithoutRecord: Array<{ phone: string }> = [];
+    const recordsWithoutChat: Array<{ phone: string; slugs: string[]; fields: string[] }> = [];
+
+    // Chats -> Records (por canonical)
+    for (const v of chatPhonesSet) {
+      if (recordPhonesSet.has(v)) matchedCanonPhones.push(v);
+    }
+    for (const c of chatsRaw) {
+      const canon = toCanonical(c?.phone);
+      if (!canon) continue;
+      if (!recordPhonesSet.has(canon)) chatsWithoutRecord.push({ phone: c.phone });
+    }
+
+    // Records -> Chats (por canonical)
+    for (const v of recordPhonesSet) {
+      if (!chatPhonesSet.has(v)) {
+        const meta = recordCanonToMeta.get(v);
+        recordsWithoutChat.push({ 
+          phone: v,
+          slugs: meta ? Array.from(meta.slugs) : [],
+          fields: meta ? Array.from(meta.fields) : []
+        });
+      }
+    }
+
+    // 6) Duplicados potenciales
+    const duplicateChats = Array.from(chatPhoneCounts.entries()).filter(([, count]) => count > 1)
+      .map(([phone, count]) => ({ phone, count }));
+
+    // Duplicados por canonical en records
+    const recordDuplicates = Array.from(recordPhoneCounts.entries()).filter(([, count]) => count > 1)
+      .map(([phone, count]) => ({ phone, count }));
+
+    // 7) Cerrar conexión independiente a chats
+    await quickLearningConnection.close();
+
+    const result = {
+      success: true,
+      params: {
+        startDate: startDate || `últimos ${period}`,
+        endDate: endDate || 'ahora',
+        includeInactive: includeInactive === 'true',
+        tableSlugs: slugs,
+        company: 'quicklearning'
+      },
+      counts: {
+        chatsRaw: chatsRaw.length,
+        chatsUnique: chatPhonesSet.size,
+        records: records.length,
+        recordsUnique: recordPhonesSet.size,
+        matchedUniquePhones: matchedCanonPhones.length,
+        chatsWithoutRecord: chatsWithoutRecord.length,
+        recordsWithoutChat: recordsWithoutChat.length,
+        duplicateChats: duplicateChats.length,
+        duplicateRecords: recordDuplicates.length
+      },
+      samples: {
+        chatsWithoutRecord: chatsWithoutRecord.slice(0, 100),
+        recordsWithoutChat: recordsWithoutChat.slice(0, 100),
+        duplicateChats: duplicateChats.slice(0, 100),
+        duplicateRecords: recordDuplicates.slice(0, 100),
+      },
+      note: 'Las comparaciones usan variantes de teléfono (original, sin +, solo dígitos) para robustez.'
+    };
+
+    return res.status(200).json(result);
+
+  } catch (error) {
+    console.error('❌ Error verificando consistencia chats vs dynamicrecords:', error);
+    return res.status(500).json({ success: false, message: 'Error interno', error: process.env.NODE_ENV === 'development' ? error : undefined });
   }
 };

--- a/src/controllers/quicklearning/twilioController.ts
+++ b/src/controllers/quicklearning/twilioController.ts
@@ -244,7 +244,7 @@ export const twilioWebhook = async (req: Request, res: Response): Promise<void> 
       emitNewMessageNotification(phoneUser, newMessage, chat);
 
       // Actualizar ultimo_mensaje y lastMessageDate en la tabla correcta si el usuario ya existe
-      const tableSlugs = ["alumnos", "prospectos", "clientes", "sin_contestar"];
+      const tableSlugs = ["alumnos", "prospectos", "clientes", "sin_contestar", "nuevo_ingreso"];
       let updated = false;
       for (const tableSlug of tableSlugs) {
         const result = await Record.updateOne(
@@ -407,14 +407,15 @@ async function processMessageWithBuffer(phoneUser: string, messageText: string, 
           }
           
           // Actualizar registros en TODAS las tablas (alumnos, prospectos, clientes, sin_contestar)
-          const tableSlugs = ["alumnos", "prospectos", "nuevo_ingreso", "sin_contestar"];
+          const tableSlugs = ["alumnos", "prospectos", "clientes", "sin_contestar", "nuevo_ingreso"];
           let updated = false;
           
           for (const tableSlug of tableSlugs) {
             try {
               const updateData: any = {
-                "data.ultimo_mensaje": currentDate,
-                "data.lastMessage": aiResponse
+                "data.ultimo_mensaje": aiResponse,
+                "data.lastMessage": aiResponse,
+                "data.lastMessageDate": currentDate
               };
               
               // Si es transferencia, también desactivar IA

--- a/src/routes/quicklearning/metricsRoutes.ts
+++ b/src/routes/quicklearning/metricsRoutes.ts
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { 
   getQuickLearningMetrics, 
-  getQuickLearningDashboard 
+  getQuickLearningDashboard,
+  checkQuickLearningChatsRecordsConsistency
 } from "../../controllers/quicklearning/metricsController";
 
 const router = Router();
@@ -138,5 +139,12 @@ router.get('/metrics', getQuickLearningMetrics);
  *         description: Error interno del servidor
  */
 router.get('/dashboard', getQuickLearningDashboard);
+
+/**
+ * Verificación de consistencia chats vs dynamicrecords
+ * GET /api/quicklearning/consistency
+ * Query: startDate, endDate, period, includeInactive, tableSlugs
+ */
+router.get('/consistency', checkQuickLearningChatsRecordsConsistency);
 
 export default router;

--- a/src/scripts/compareChatsVsRecords.ts
+++ b/src/scripts/compareChatsVsRecords.ts
@@ -1,0 +1,174 @@
+import mongoose, { Connection, Model } from 'mongoose';
+import { getQuickLearningConnection, getConnectionByCompanySlug } from '../config/connectionManager';
+import getRecordModel from '../models/record.model';
+
+type CanonicalPhone = string;
+
+function parseArg(name: string, fallback?: string): string | undefined {
+  const match = process.argv.find(arg => arg.startsWith(`--${name}=`));
+  if (!match) return fallback;
+  const [, value] = match.split('=');
+  return value;
+}
+
+function toDayKey(date: Date): string {
+  const d = new Date(date);
+  return d.toISOString().split('T')[0];
+}
+
+function startOfDay(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function endOfDay(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(23, 59, 59, 999);
+  return d;
+}
+
+function toCanonicalPhone(value: unknown): CanonicalPhone | null {
+  if (value === undefined || value === null) return null;
+  const s = String(value).trim();
+  if (!s) return null;
+  const digitsOnly = s.replace(/\D+/g, '');
+  return digitsOnly || null;
+}
+
+async function main(): Promise<void> {
+  const startStr = parseArg('start');
+  const endStr = parseArg('end');
+  const slugsStr = parseArg('slugs', 'alumnos,prospectos,clientes,sin_contestar,nuevo_ingreso');
+
+  if (!startStr || !endStr) {
+    console.error('Usage: ts-node src/scripts/compareChatsVsRecords.ts --start=YYYY-MM-DD --end=YYYY-MM-DD [--slugs=csv]');
+    process.exit(1);
+  }
+
+  const startDate = startOfDay(new Date(startStr));
+  const endDate = endOfDay(new Date(endStr));
+  const tableSlugs = slugsStr.split(',').map(s => s.trim()).filter(Boolean);
+
+  const qlConn: Connection = await getQuickLearningConnection();
+  const companyConn: Connection = await getConnectionByCompanySlug('quicklearning');
+
+  // Chats model (minimal)
+  const chatSchema = new mongoose.Schema({
+    phone: String,
+  }, { timestamps: true, collection: 'chats' });
+  const Chat: Model<any> = qlConn.model('Chat', chatSchema);
+
+  // Dynamic Records
+  const Record = getRecordModel(companyConn);
+
+  // Load data in range
+  const [chats, records] = await Promise.all([
+    Chat.find({ createdAt: { $gte: startDate, $lte: endDate } }).select('phone createdAt').lean(),
+    Record.find({
+      c_name: 'quicklearning',
+      tableSlug: { $in: tableSlugs },
+      createdAt: { $gte: startDate, $lte: endDate }
+    }).select('createdAt tableSlug data.telefono data.phone data.number').lean()
+  ]);
+
+  // Aggregate chats by canonical phone and by day
+  const chatCanonToCreated: Map<CanonicalPhone, Date> = new Map();
+  const chatsByDay: Map<string, Set<CanonicalPhone>> = new Map();
+  const duplicateChatPhones: Map<CanonicalPhone, number> = new Map();
+
+  for (const c of chats) {
+    const canon = toCanonicalPhone(c?.phone);
+    if (!canon) continue;
+    const created = new Date(c.createdAt);
+    const key = toDayKey(created);
+    if (!chatsByDay.has(key)) chatsByDay.set(key, new Set());
+    const daySet = chatsByDay.get(key)!;
+    daySet.add(canon);
+    if (chatCanonToCreated.has(canon)) {
+      duplicateChatPhones.set(canon, (duplicateChatPhones.get(canon) || 1) + 1);
+    } else {
+      chatCanonToCreated.set(canon, created);
+    }
+  }
+
+  // Aggregate records by canonical phone and by day
+  const recordCanonToCreated: Map<CanonicalPhone, { date: Date, slug: string }[]> = new Map();
+  const recordsByDay: Map<string, Set<CanonicalPhone>> = new Map();
+  const duplicateRecordPhones: Map<CanonicalPhone, number> = new Map();
+
+  for (const r of records as any[]) {
+    const priority = r?.data?.telefono ?? r?.data?.phone ?? r?.data?.number;
+    const canon = toCanonicalPhone(priority);
+    if (!canon) continue;
+    const created = new Date(r.createdAt);
+    const key = toDayKey(created);
+    if (!recordsByDay.has(key)) recordsByDay.set(key, new Set());
+    recordsByDay.get(key)!.add(canon);
+    const arr = recordCanonToCreated.get(canon) || [];
+    arr.push({ date: created, slug: r.tableSlug });
+    recordCanonToCreated.set(canon, arr);
+    if (arr.length > 1) duplicateRecordPhones.set(canon, arr.length);
+  }
+
+  // Differences per day
+  const dayKeys: string[] = [];
+  for (let d = new Date(startDate); d <= endDate; d = new Date(d.getTime() + 24 * 60 * 60 * 1000)) {
+    dayKeys.push(toDayKey(d));
+  }
+
+  const daily = dayKeys.map(day => {
+    const chatSet = chatsByDay.get(day) || new Set<CanonicalPhone>();
+    const recSet = recordsByDay.get(day) || new Set<CanonicalPhone>();
+    const chatsWithoutRecord: CanonicalPhone[] = [];
+    const recordsWithoutChat: CanonicalPhone[] = [];
+    chatSet.forEach(p => { if (!recSet.has(p)) chatsWithoutRecord.push(p); });
+    recSet.forEach(p => { if (!chatSet.has(p)) recordsWithoutChat.push(p); });
+    return {
+      day,
+      chatsCreated: chatSet.size,
+      recordsCreated: recSet.size,
+      delta: chatSet.size - recSet.size,
+      chatsWithoutRecord: chatsWithoutRecord.slice(0, 50),
+      recordsWithoutChat: recordsWithoutChat.slice(0, 50)
+    };
+  });
+
+  // Overall sets
+  const allChatPhones = new Set<CanonicalPhone>(Array.from(chatCanonToCreated.keys()));
+  const allRecordPhones = new Set<CanonicalPhone>(Array.from(recordCanonToCreated.keys()));
+
+  const overallChatsWithoutRecord: CanonicalPhone[] = [];
+  const overallRecordsWithoutChat: CanonicalPhone[] = [];
+  allChatPhones.forEach(p => { if (!allRecordPhones.has(p)) overallChatsWithoutRecord.push(p); });
+  allRecordPhones.forEach(p => { if (!allChatPhones.has(p)) overallRecordsWithoutChat.push(p); });
+
+  const summary = {
+    range: { start: startDate.toISOString(), end: endDate.toISOString() },
+    tableSlugs,
+    totals: {
+      chats: allChatPhones.size,
+      records: allRecordPhones.size,
+      delta: allChatPhones.size - allRecordPhones.size
+    },
+    duplicates: {
+      chats: Array.from(duplicateChatPhones.entries()).slice(0, 50).map(([phone, count]) => ({ phone, count })),
+      records: Array.from(duplicateRecordPhones.entries()).slice(0, 50).map(([phone, count]) => ({ phone, count }))
+    },
+    overallDiff: {
+      chatsWithoutRecord: overallChatsWithoutRecord.slice(0, 200),
+      recordsWithoutChat: overallRecordsWithoutChat.slice(0, 200)
+    },
+    daily
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('Error running comparison script:', err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
…námicos

- Implementar un nuevo endpoint para verificar la consistencia entre los chats y los registros en la base de datos.
- Añadir un script para comparar chats y registros por rango de fechas y slugs seleccionados.
- Mejorar la recolección de métricas en el controlador de QuickLearning, incluyendo nuevos campos y cálculos para prospectos y registros creados.