### PR TITLE
feat: agregar endpoint para generar prompt desde chats de WhatsApp

### DIFF
--- a/src/routes/iaConfig.routes.ts
+++ b/src/routes/iaConfig.routes.ts
@@ -1,11 +1,14 @@
 import { Router } from "express";
-import { createIAConfig , deleteIAConfig, getAllIAConfigs, getGeneralIAConfig, testIA, updateIAConfig} from "../controllers/iaConfig.controller";
+import { createIAConfig , deleteIAConfig, getAllIAConfigs, getGeneralIAConfig, testIA, updateIAConfig, generateWhatsappPromptFromChats} from "../controllers/iaConfig.controller";
 
 const router = Router();
 
 router.post("/:c_name", createIAConfig);
 
 router.post("/testIA/:c_name", testIA);
+
+// Admin-only: generar prompt desde todos los chats de WhatsApp (solo devuelve promptDraft)
+router.post("/:c_name/:user_id/whatsapp/prompt-from-chats", generateWhatsappPromptFromChats);
 
 router.get("/:c_name/:user_id", getAllIAConfigs);
 


### PR DESCRIPTION
- Implementar un nuevo endpoint que permite a los administradores generar un prompt basado en todos los chats de WhatsApp.
- Incluir validaciones de permisos y filtros opcionales por rango de fechas y muestreo.
- Construir el prompt a partir de pares de mensajes reales, con métricas sobre el tono y patrones de respuesta.